### PR TITLE
Replace lazy_static with LazyLock

### DIFF
--- a/prometheus-metric-storage/Cargo.toml
+++ b/prometheus-metric-storage/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/taminomara/prometheus-metric-storage"
 documentation = "https://docs.rs/prometheus-metric-storage"
 description = "Derive macro to instantiate and register prometheus metrics without having to write tons of boilerplate code"
 readme = "../README.md"
+rust-version = "1.80.0"
 
 [dependencies]
 prometheus = {version = "0.13", default_features=false}
 prometheus-metric-storage-derive = { version = "0.5.0", path = "../prometheus-metric-storage-derive" }
-lazy_static = "1.4"

--- a/prometheus-metric-storage/src/lib.rs
+++ b/prometheus-metric-storage/src/lib.rs
@@ -359,7 +359,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 #[doc(hidden)]
 pub use prometheus::{Error, Opts, Registry, Result};
@@ -565,11 +565,8 @@ impl Debug for StorageRegistry {
 
 /// Get the default storage registry that uses [`prometheus::default_registry`].
 pub fn default_storage_registry() -> &'static StorageRegistry {
-    lazy_static::lazy_static! {
-        static ref REGISTRY: StorageRegistry =
-            StorageRegistry::new(prometheus::default_registry().clone());
-    }
-
+    static REGISTRY: LazyLock<StorageRegistry> =
+        LazyLock::new(|| StorageRegistry::new(prometheus::default_registry().clone()));
     &REGISTRY as &StorageRegistry
 }
 


### PR DESCRIPTION
This PR replaces the lazy_static library with LazyLock and bumps the MSRV to 1.80

I suggest not bumping the version *yet* as:
* We use this library at https://github.com/cowprotocol/services and it's blocking us from upgrading to prometheus 0.14, so I'm taking the time to provide some upgrades (more to come)
* Doing a minor bump with this change can break the downstream package websocat ([their non official MSRV is 1.48](https://github.com/vi/websocat/blob/master/Cargo.toml#L12))