### PR TITLE
Upgrade prometheus to 0.14

### DIFF
--- a/prometheus-metric-storage/Cargo.toml
+++ b/prometheus-metric-storage/Cargo.toml
@@ -11,6 +11,6 @@ description = "Derive macro to instantiate and register prometheus metrics witho
 readme = "../README.md"
 
 [dependencies]
-prometheus = {version = "0.13", default_features=false}
+prometheus = {version = "0.14", default_features=false}
 prometheus-metric-storage-derive = { version = "0.5.0", path = "../prometheus-metric-storage-derive" }
 lazy_static = "1.4"


### PR DESCRIPTION
This PR upgrades prometheus to 0.14, unblocking our prometheus upgrade for https://github.com/cowprotocol/services